### PR TITLE
Change character encoding of all nuspec files to UTF-8

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.app</id>

--- a/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.tool</id>

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.app</id>

--- a/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.tool</id>

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>


### PR DESCRIPTION
I discovered that the nuspec files were saved in the (in my opinion obsolete) ANSI character encoding. This leads to several problems with special characters. Here is an example: https://chocolatey.org/packages/uTorrent.
Switching to UTF-8 solves this problem, because also the Chocolatey website uses this encoding.
All modern Linux distributions switched to UTF-8 several years ago. But even in Windows 8 when a new plain text file is created, it uses ANSI as character encoding.
I do not understand why Microsoft is still using such outdated and superseded standards like ANSI. That’s a big boo for the Microsoft gods. ;)
