### PR TITLE
Change URL format for icons from GitHub

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="7zip.commandline" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.app" version="[__REPLACE__]" />
     </dependencies>

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="{{PackageVersion}}" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <!--<dependencies>
       <dependency id="7zip.commandline" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/raw/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.app" version="[{{PackageVersion}}]" />
     </dependencies>


### PR DESCRIPTION
I had a [pull request](https://github.com/bdukes/nugetpackages/pull/2) on one of my packages to change the URL format for the icon that I was referencing, so figured I'd push that out to the templates (the old format still works, just redirects to the new format, so it's not a very important change).
