### PR TITLE
PNG instead of GIF

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolatey3/__NAME__.app/__NAME__.app.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolatey3/__NAME__.tool/__NAME__.tool.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="7zip.commandline" />
     </dependencies>-->

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.app" version="[__REPLACE__]" />
     </dependencies>

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="{{PackageVersion}}" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.app/__NAME__.app.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.tool/__NAME__.tool.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="7zip.commandline" />
     </dependencies>-->

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.gif</iconUrl>-->
+    <!--<iconUrl>https://raw.github.com/__CHOCO_AUTO_PKG_OWNER_REPO__/master/__NAME__/__NAME__.png</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.app" version="[{{PackageVersion}}]" />
     </dependencies>


### PR DESCRIPTION
Better use PNG instead of GIF as standard graphics format.
GIF is deprecated and has several drawbacks:
- only 256 colours
- no alpha-transparency
- less compression than PNG
