### PR TITLE
README.md: added maintainer term, some typographical improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 chocolateytemplates
 ===================
 
-The templates...
+The templates …
   
   
-...it's all about the templates.
+… it’s all about the templates.
 
 ##Welcome to the simple way of creating chocolatey packages
 Take a look at this repository (note the _templates folder).
@@ -23,9 +23,9 @@ Now open a command line, navigate to your source code top level folder and type 
  warmup addTemplateFolder chocolateyauto3 "%cd%\chocolateyauto3"
 ```
   
- * The package owner name (__CHOCO_PKG_OWNER_NAME__) would be you. 
+ * The package maintainer (owner) name (__CHOCO_PKG_OWNER_NAME__) would be you. 
  * Your packages repository (__CHOCO_PKG_OWNER_REPO__) is part of a github repo just **ferventcoder/nugetpackages** if your repository is https://github.com/ferventcoder/nugetpackages. This is only used for image urls.
- * Your chocolatey automatic packages repository (__CHOCO_AUTO_PKG_OWNER_REPO__) could be the same as your regular packages repository. This is also the same as package owner repo. This is only used for image urls.  
+ * Your chocolatey automatic packages repository (__CHOCO_AUTO_PKG_OWNER_REPO__) could be the same as your regular packages repository. This is also the same as package maintainer (owner) repo. This is only used for image urls.  
 
 Now whenever you want to create a new package you just open a command line and navigate to your packages repository source code folder (or install stexbar `cinst stexbar` and just hit Ctrl+M from explorer).  
   


### PR DESCRIPTION
“Maintainer” is now the official term, “owner” is deprecated, see https://github.com/chocolatey/chocolatey.org/issues/47 and https://github.com/chocolatey/chocolatey.org/pull/49. Of course here we have the problem that NuGet’s `<owners>` tag still exists and the warmup variables also contain “OWNER”. Do you have an idea how to handle that?

Typographical improvements:
- There exists an Unicode character for ellipses: `…`
- A space needs to be added before/after the ellipsis if the word after/before is complete.
- Replaced the “typewriter apostrophe” `'` with the typographically correct apostrophe `’`.

I know, these are tiny corrections, but I really like good typography. :smiley:
It’s a pity that most of these typographically correct characters can not be written with the normal QWERT layout. But I can write them directly, because I use the [Neo keyboard layout](https://en.wikipedia.org/wiki/Keyboard_layout#Neo) instead. It’s definitely the most awesome and the most advanced keyboard layout in the world. I would never switch back to QWERT.
