### PR TITLE
Convert CRLF to LF in *.nuspec files, insert a comment to make sure that it gets parsed as UTF-8

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.install</id>

--- a/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.portable</id>

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>

--- a/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.install</id>

--- a/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__.portable</id>

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>__NAME__</id>


### PR DESCRIPTION
Unfortunately the diffs on GitHub for commits with end-of-line character conversions aren’t really intuitive. It shows the entire file as changed. There should be an option like `diff -w` to ignore white space.
