### PR TITLE
Add note about https://cdn.rawgit.com which caches files permanently

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />

--- a/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />

--- a/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" />

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.install" version="[__REPLACE__]" />

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="{{PackageVersion}}" />

--- a/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" version="" />

--- a/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <!--<dependencies>
       <dependency id="" />

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -15,6 +15,7 @@
     <copyright></copyright>
     <licenseUrl>__REPLACE__</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!-- Important note about https://cdn.rawgit.com: Files are cached permanently after the first request. Use commit URLs when updating the icon. -->
     <!--<iconUrl>http://cdn.rawgit.com/__CHOCO_PKG_MAINTAINER_REPO__/master/icons/__NAME__.png</iconUrl>-->
     <dependencies>
       <dependency id="__NAME__.install" version="[{{PackageVersion}}]" />


### PR DESCRIPTION
During moderation I discovered that many maintainers are unaware of the fact that https://cdn.rawgit.com caches files permanently after the first request and wondered why the branch URL didn’t update to the new icon.

With this comment in the nuspecs this will be less often the case. I guess you still remember why we chose to use cdn.rawgit.com. Exactly because of the permanent caching so that we don’t have problems with disappearing icons, which bothered us much in the past. :smiley: 

I really hope that either NuGet or Chocolatey fixes this flawed design of icon URLs. An icon should go **inside** the package and served by the Gallery itself and not included as URL to an external resource.