### PR TITLE
Note about not indenting the contents of <description> and <releaseNotes>

### DIFF
--- a/_templates/chocolatey/__NAME__.nuspec
+++ b/_templates/chocolatey/__NAME__.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__ admin</tags>
     <copyright></copyright>

--- a/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolatey3/__NAME__.install/__NAME__.install.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__ admin</tags>
     <copyright></copyright>

--- a/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolatey3/__NAME__.portable/__NAME__.portable.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__</tags>
     <copyright></copyright>

--- a/_templates/chocolatey3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolatey3/__NAME__/__NAME__.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__</tags>
     <copyright></copyright>

--- a/_templates/chocolateyauto/__NAME__.nuspec
+++ b/_templates/chocolateyauto/__NAME__.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__ admin</tags>
     <copyright></copyright>

--- a/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.install/__NAME__.install.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__ admin</tags>
     <copyright></copyright>

--- a/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
+++ b/_templates/chocolateyauto3/__NAME__.portable/__NAME__.portable.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__</tags>
     <copyright></copyright>

--- a/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
+++ b/_templates/chocolateyauto3/__NAME__/__NAME__.nuspec
@@ -9,7 +9,10 @@
     <authors>__REPLACE__</authors>
     <owners>__CHOCO_PKG_MAINTAINER_NAME__</owners>
     <summary>__REPLACE__</summary>
-    <description>__REPLACE__</description>
+    <!-- Note: <description> and <releaseNotes> are parsed as Markdown, so don’t indent their content (see https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-description-and-release-notes). -->
+    <description>
+__REPLACE__
+    </description>
     <projectUrl>__REPLACE__</projectUrl>
     <tags>__NAME__</tags>
     <copyright></copyright>


### PR DESCRIPTION
This is one of the most common things that package maintainers overlook, which then results in unintended code block formatting in the Gallery. 

I think it’s worth to add a note about it directly in the nuspec too.